### PR TITLE
[STYLE] 그룹 랭킹 페이지의 스타일을 수정합니다

### DIFF
--- a/src/main/java/com/devturtle/rank/RankGroupServlet.java
+++ b/src/main/java/com/devturtle/rank/RankGroupServlet.java
@@ -2,17 +2,19 @@ package com.devturtle.rank;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
 import com.devturtle.common.PagingUtil;
 import com.devturtle.group.GroupDAO;
 import com.devturtle.group.GroupVO;
+import com.devturtle.mission.MissionGroupDAO;
 
 @WebServlet("/rankGroup")
 public class RankGroupServlet extends HttpServlet {
@@ -36,6 +38,8 @@ public class RankGroupServlet extends HttpServlet {
 //		
 		
 		GroupDAO gdao = new GroupDAO();
+		MissionGroupDAO mdao = new MissionGroupDAO();
+		
 		int currentPage = 1;
 		String currentPageStr = request.getParameter("currentPage");
 		if(currentPageStr != null && !currentPageStr.equals(""))  {
@@ -53,9 +57,17 @@ public class RankGroupServlet extends HttpServlet {
 		
 		ArrayList<GroupVO> glist = gdao.selectAllGroupByMonthOrderByRankPaging("20250102", pg.getStartSeq(), pg.getEndSeq());
 		request.setAttribute("GLIST", glist);
+		
+		// 각 그룹의 사용자 수
+        Map<Integer, Integer> groupUserCountMap = new HashMap<>();
+        for (GroupVO group : glist) {
+            int userCount = gdao.getNumberOfGroupUser(group.getGroupId());
+            groupUserCountMap.put(group.getGroupId(), userCount);  
+        }
+
+        request.setAttribute("GROUP_USER_COUNT", groupUserCountMap);		
 
 		request.setAttribute("contentPage", "/jsp/rank/rank_group.jsp");
-		
 	    request.getRequestDispatcher("/index.jsp").forward(request, response);	
 	}
 

--- a/src/main/webapp/css/paging/paging.css
+++ b/src/main/webapp/css/paging/paging.css
@@ -7,23 +7,24 @@
 
 .pagination a {
     text-decoration: none;
-    color: #007bff;
     font-weight: bold;
-    border: 1px solid #007bff;
+    border: 2px solid var(--main-color);
     border-radius: 4px;
     padding: 8px 12px;
     margin: 0 5px;
     transition: all 0.3s ease;
+    color: var(--main-color);
 }
 
 .pagination a:hover {
-    background-color: #007bff;
+    background-color: #95c947;
     color: #fff;
+    border: 2px solid #95c947;
 }
 
 .pagination a.active {
-    background-color: #007bff;
-    color: #fff;
+    background-color: var(--main-color);
+    color: var(--back-color);
     cursor: default;
 }
 

--- a/src/main/webapp/css/rank/rank.css
+++ b/src/main/webapp/css/rank/rank.css
@@ -1,137 +1,99 @@
-@import "../common/reset.css";
-@import "../common/color.css";
 @import "../paging/paging.css";
 
-@font-face {
-  font-family: "DungGeunMo";
-  src: url("./assets/DungGeunMo.ttf") format("ttf");
+#group-rank-title {
+    font-size: 30px;
+	color: var(--main-color);
+	width: 100%;
+	text-align: center;
 }
 
-body {
-  font-family: "DungGeunMo";
-  color: var(--font-gray-color);
-  background-color: var(--back-color);
-  padding-top: 40px;
-  padding-bottom: 40px;
-  padding-left: 60px;
-  padding-right: 60px; 
-}
-
-input {
-  font-family: "DungGeunMo";
-}
-
-button {
-  font-family: "DungGeunMo";
-}
-
-/* 로고 스타일 */
-.logo {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding-bottom: 50px; /* 간격 수정 */
-}
-
-.logo a {
-  text-decoration: none;
-  color: #b3ff43;
-  display: flex;
-  align-items: center;
-  font-size: 22px; /* 크기 증가 */
-}
-
-.logo img {
-  width: 90px; /* 크기 증가 */
-  height: auto;
-  margin-right: 20px; /* 간격 증가 */
-}
-
-.input-container {
-  position: relative;
-}
-
-/* 텍스트 필드 스타일 */
-.input-container input {
-  width: 40%;
-  padding: 14px 40px 14px 14px;
-  border: 2px solid #304d5d;
-  border-radius: 5px;
-  background-color: #01131f;
-  color: #304d5d;
-  font-size: 16px;
-  font-family: "DungGeunMo", Arial, sans-serif;
-  box-sizing: border-box;
-}
-
-
-h1 {
-    text-align: center;
-    margin: 20px;
-    color: #64ffda;
-}
-
-.container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+.group-rank-container {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     gap: 20px;
-    margin: 20px;
+    padding-top: 30px;
+    padding-bottom: 30px;
 }
 
-.card {
-    background-color: #2d3748;
+.group-rank-card {
+    background-color: var(--depth-second-color);
     border-radius: 10px;
     padding: 20px;
-    width: 300px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
     transition: 0.3s;
 }
 
-.card:hover {
+.group-rank-card:hover {
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
 }
 
-.card-header {
+.group-rank-card-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 15px;
 }
 
-.card-header h2 {
-    font-size: 18px;
-    color: #fbd38d;
+.group-rank-card-header h2 {
+    font-size: 24px;
+    color: var(--font-bright-color);
     margin: 0;
 }
 
-.card-content {
+.group-rank-card-title {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.group-name {
+	font-size: 20px;
+	color: var(--main-color);
+    text-decoration: none;
+}
+
+.group-people {
+	display: flex;
+	align-items: center;
+	gap: 3px;
+}
+
+.group-people img{
+	width: 15px;
+	height: 15px;
+}
+
+.group-rank-card-content {
     margin-top: 10px;
 }
 
-.card-content p {
+.group-rank-card-content p {
     margin: 5px 0;
-    font-size: 14px;
+
 }
 
-.card-footer {
+.group-rank-card-footer {
     margin-top: 15px;
     text-align: right;
+    font-size: 20px;
+}
+
+.group-rank-card-footer strong{
+    color: var(--main-color);
 }
 
 .follow-btn {
-    background-color: #64ffda;
+    background-color: var(--main-color);
     border: none;
     border-radius: 5px;
-    padding: 5px 10px;
+    padding: 5px 20px;
     cursor: pointer;
-    color: #1e293b;
-    font-weight: bold;
+    color: var(--back-color);
     transition: 0.3s;
+    font-size:24px;
 }
 
 .follow-btn:hover {
-    background-color: #81e6d9;
+    background-color: #95c947;
 }
 
 

--- a/src/main/webapp/jsp/rank/rank_group.jsp
+++ b/src/main/webapp/jsp/rank/rank_group.jsp
@@ -2,11 +2,6 @@
     pageEncoding="UTF-8"%>
     
 <%@ taglib prefix="c" 	uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" 	uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="fn" 	uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="x" 	uri="http://java.sun.com/jsp/jstl/xml" %>
-<%@ taglib prefix="sql" 	uri="http://java.sun.com/jsp/jstl/sql" %>    
-<%-- <%@ include file="/jsp/layout/header.jsp" %> --%>
 
 <!DOCTYPE html>
 <html>
@@ -18,30 +13,33 @@
 </head>
 <body>
 
-<h1>그룹 랭킹 정보</h1>
-    <div class="container">
+<h1 id="group-rank-title">👑 이번 달 그룹 랭킹</h1>
+    <div class="group-rank-container">
         <c:forEach var="gvo" items="${GLIST}">
-            <div class="card">
-                <div class="card-header">
-                    <h2> ${gvo.rank} ${gvo.name}</h2>
-                    <button class="follow-btn">Join</button>
-                </div>
-                <div class="card-content">
-                    <p><strong>그룹 소개:</strong> ${gvo.description}</p>
-                    <p><strong>전체 점수:</strong> ${gvo.totalScore}</p>
-                </div>
-                <div class="card-footer">
-                    <p><strong>POINT:</strong> ${gvo.totalScore}</p>
-                </div>
+            <div class="group-rank-card" >
+	                <div class="group-rank-card-header">
+	                    <h2> ${gvo.rank}위</h2>     
+	                    <button class="follow-btn">Join</button>
+	                </div>
+	                <div class="group-rank-card-title">
+	                	<a href="${pageContext.request.contextPath}/groupdetail?groupid=${gvo.groupId}" class="group-name"> ${gvo.name}</a>
+	                	<p class="group-people">
+	                		<img src="${pageContext.request.contextPath}/assets/main/follower.svg" />
+	                		<span>${GROUP_USER_COUNT[gvo.groupId]}명</span>
+	                	</p>
+	                </div>
+	                <div class="group-rank-card-content">
+	                    <p>${gvo.description}</p>
+	                </div>
+	                <div class="group-rank-card-footer">
+	                    <p>TOTAL POINT <strong>${gvo.totalScore}P</strong></p>
+	                </div>
+               	
             </div>
         </c:forEach>
     </div>
 
 ${MY_KEY_PAGING_HTML}
-
-<%-- <%@ include file="/jsp/layout/footer.jsp" %> --%>
-
-
 
 <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
 <script>


### PR DESCRIPTION
## 🔗 관련 이슈
Resolved: #10 

## 📌 변경 사항 개요
- [x] 기존 그룹 랭킹 페이지의 전반적인 UI을 다른 페이지와 일관성있게 수정합니다
- [x] 기존 그룹 랭킹 페이지의 컬러값을 다른 페이지와 일관성있게 공통 컬러값으로 수정합니다
- [x] 그룹 랭킹 페이지에 그룹별 인원수를 추가합니다
- [x] 그룹 이름을 클릭 시 해당 그룹의 상세 페이지로 이동합니다
- [x] 페이지네이션의 css를 수정합니다

## 🛠 변경 세부 사항
- 하단 스크린샷 참고

## 📷 스크린샷
- 기존 
![image](https://github.com/user-attachments/assets/24711823-163b-4fe8-97d8-2216dabc9ab0)
- 수정본
![image](https://github.com/user-attachments/assets/5706ae30-6b5c-474c-9dbf-c031855dc5f3)

## 📝 추가 설명
- 페이지 담당자: @Hoshi03 